### PR TITLE
adding to/from Penman/Graph/Tree convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,36 +23,41 @@ npm install penman-js
 
 ## Basic usage
 
-The most faithful representation of AMR text in the library is the `Tree` class. The `parse` function turns an AMR text string into a `Tree`, and `format` does the reverse, turning a `Tree` back into a string.
+The most faithful representation of AMR text in the library is the `Tree` class. The `Tree.fromPenman()` method turns an AMR text string into a `Tree`, and `tree.toPenman()` does the reverse, turning a `Tree` back into a string.
 
 ```js
-import { parse, format } from 'penman-js';
+import { Tree } from 'penman-js';
 
-const t = penman.parse('(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))');
-const [variable, branches] = t.node;
+const tree = Tree.fromPenman(
+  '(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))',
+);
+const [variable, branches] = tree.node;
 console.log(variable); // ouput: 'w'
 console.log(branches.length); // output: 3
 const [role, target] = branches[2];
 console.log(role); // output: ':ARG1'
-console.log(format(target));
+const subtree = new Tree(target);
+console.log(subtree.toPenman());
 // (g / go
 //     :ARG0 b)
 ```
 
-Users wanting to interact with graphs might find the `decode` and
-`encode` functions a good place to start.
+Users wanting to interact with graphs might find the `Graph.fromPenman()` and
+`graph.toPenman()` methods a good place to start.
 
 ```js
-import { encode, decode } from 'penman-js';
-const g = penman.decode('(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))');
-console.log(g.top);
+import { Graph } from 'penman-js';
+const graph = Graph.fromPenman(
+  '(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))',
+);
+console.log(graph.top);
 // 'w'
-console.log(g.triples.length);
+console.log(graph.triples.length);
 // 6
-console.log(g.instances().map((instance) => instance[2]));
+console.log(graph.instances().map((instance) => instance[2]));
 // ['want-01', 'boy', 'go']
 
-console.log(encode(g, { top: 'b' }));
+console.log(graph.toPenman({ top: 'b' }));
 // (b / boy
 //    :ARG0-of (w / want-01
 //                :ARG1 (g / go

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -10,42 +10,43 @@ npm install penman-js
 
 ## Basic usage
 
-The most faithful representation of AMR text in the library is the `Tree` class. The `parse` function turns an AMR text string into a `Tree`, and `format` does the reverse, turning a `Tree` back into a string.
+The most faithful representation of AMR text in the library is the `Tree` class. The `Tree.fromPenman()` method turns an AMR text string into a `Tree`, and `tree.toPenman()` does the reverse, turning a `Tree` back into a string.
 
 ```js
-import { parse, format } from 'penman-js';
+import { Tree } from 'penman-js';
 
-const t = penman.parse('(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))');
-const [variable, branches] = t.node;
+const tree = Tree.fromPenman(
+  '(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))',
+);
+const [variable, branches] = tree.node;
 console.log(variable); // ouput: 'w'
 console.log(branches.length); // output: 3
 const [role, target] = branches[2];
 console.log(role); // output: ':ARG1'
-console.log(format(target));
+const subtree = new Tree(target);
+console.log(subtree.toPenman());
 // (g / go
 //     :ARG0 b)
 ```
 
-Users wanting to interact with graphs might find the `decode` and
-`encode` functions a good place to start.
+Users wanting to interact with graphs might find the `Graph.fromPenman()` and
+`graph.toPenman()` methods a good place to start.
 
 ```js
-import { encode, decode } from 'penman-js';
-const g = penman.decode('(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))');
-console.log(g.top);
+import { Graph } from 'penman-js';
+const graph = Graph.fromPenman(
+  '(w / want-01 :ARG0 (b / boy) :ARG1 (g / go :ARG0 b))',
+);
+console.log(graph.top);
 // 'w'
-console.log(g.triples.length);
+console.log(graph.triples.length);
 // 6
-console.log(g.instances().map((instance) => instance[2]));
+console.log(graph.instances().map((instance) => instance[2]));
 // ['want-01', 'boy', 'go']
 
-console.log(encode(g, { top: 'b' }));
+console.log(graph.toPenman({ top: 'b' }));
 // (b / boy
 //    :ARG0-of (w / want-01
 //                :ARG1 (g / go
 //                         :ARG0 b)))
 ```
-
-The `decode` and `encode` functions work with one PENMAN
-graph. The `load` and `dump` functions work with
-collections of graphs.

--- a/docs/docs/trees-graphs-epigraphs.md
+++ b/docs/docs/trees-graphs-epigraphs.md
@@ -18,6 +18,16 @@ string is **formatting**, while the whole process is called
 ![The three stages of PENMAN structure](/img/representations.png)
 </div>
 
+These functions for moving between Penman notation, trees, and graphs are also
+available in Penman JS as methods on `Graph` and `Tree` objects, as below:
+
+- `Graph.fromPenman()`: equivalent of `decode()` above
+- `graph.toPenman()`: equivalent of `encode()` above
+- `graph.toTree()`: equivalent of `configure()` above
+- `Tree.fromPenman()`: equivalent of `parse()` above
+- `tree.toPenman()`: equivalent of `format()` above
+- `tree.toGraph()`: equivalent of `interpret()` above
+
 Conversion from a PENMAN string to a `Tree`, and
 vice versa, is straightforward and lossless. Conversion to a
 `Graph`, however, is potentially lossy as the

--- a/src/lib/codec.ts
+++ b/src/lib/codec.ts
@@ -226,7 +226,7 @@ export class PENMANCodec {
  *
  * @param s - A string containing a single PENMAN-serialized graph.
  * @param options - Optional arguments.
- *   - `model` - The model used for interpreting the graph.
+ * @param options.model - The model used for interpreting the graph.
  * @returns The Graph object described by `s`.
  * @example
  * import { decode } from 'penman-js';
@@ -247,7 +247,7 @@ export function decode(s: string, options: DecodeOptions = {}): Graph {
  *
  * @param lines - A string or open file containing PENMAN-serialized graphs.
  * @param options - Optional arguments.
- *   - `model` - The model used for interpreting the graph.
+ * @param options.model - The model used for interpreting the graph.
  * @returns An iterator yielding `Graph` objects described in `lines`.
  * @example
  * import { iterdecode } from 'penman-js';

--- a/src/lib/graph.spec.ts
+++ b/src/lib/graph.spec.ts
@@ -31,6 +31,79 @@ test('init', (t) => {
   t.is(g3.top, 'b');
 });
 
+test('Graph.fromPenman', (t) => {
+  // unlabeled single node
+  let g = Graph.fromPenman('(a)');
+  t.is(g.top, 'a');
+  t.deepEqual(g.triples, [['a', ':instance', null]]);
+
+  // labeled node
+  g = Graph.fromPenman('(a / alpha)');
+  t.is(g.top, 'a');
+  t.deepEqual(g.triples, [['a', ':instance', 'alpha']]);
+
+  // unlabeled edge to unlabeled node
+  g = Graph.fromPenman('(a : (b))');
+  t.is(g.top, 'a');
+  t.deepEqual(g.triples, [
+    ['a', ':instance', null],
+    ['a', ':', 'b'],
+    ['b', ':instance', null],
+  ]);
+
+  // inverted unlabeled edge
+  g = Graph.fromPenman('(b :-of (a))');
+  t.is(g.top, 'b');
+  t.deepEqual(g.triples, [
+    ['b', ':instance', null],
+    ['a', ':', 'b'],
+    ['a', ':instance', null],
+  ]);
+
+  // labeled edge to unlabeled node
+  g = Graph.fromPenman('(a :ARG (b))');
+  t.is(g.top, 'a');
+  t.deepEqual(g.triples, [
+    ['a', ':instance', null],
+    ['a', ':ARG', 'b'],
+    ['b', ':instance', null],
+  ]);
+
+  // inverted edge
+  g = Graph.fromPenman('(b :ARG-of (a))');
+  t.is(g.top, 'b');
+  t.deepEqual(g.triples, [
+    ['b', ':instance', null],
+    ['a', ':ARG', 'b'],
+    ['a', ':instance', null],
+  ]);
+
+  // fuller examples
+  t.deepEqual(Graph.fromPenman(x1()[0]).triples, x1()[1]);
+});
+
+test('toTree', (t) => {
+  const g = new Graph([
+    ['b', ':instance', 'bark-01'],
+    ['b', ':ARG0', 'd'],
+    ['d', ':instance', 'dog'],
+  ]);
+
+  const tree = g.toTree();
+  t.deepEqual(tree.node, [
+    'b',
+    [
+      ['/', 'bark-01'],
+      [':ARG0', ['d', [['/', 'dog']]]],
+    ],
+  ]);
+});
+
+test('toPenman', (t) => {
+  const g = new Graph([['h', 'instance', 'hi']]);
+  t.deepEqual(g.toPenman(), '(h / hi)');
+});
+
 test('__or__', (t) => {
   const p = new Graph();
   const g = p.__or__(p);

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -123,12 +123,12 @@ export interface InterpretOptions {
  * @example
  * import { Tree, interpret } from 'penman-js';
  *
- * const t = new Tree('b', [
+ * const t = new Tree(['b', [
  *   ['/', 'bark-01'],
- *   ['ARG0', new Tree('d', [
+ *   ['ARG0', ['d', [
  *     ['/', 'dog']
- *   ])]
- * ]);
+ *   ]]]
+ * ]]);
  *
  * const g = interpret(t);
  * for (const triple of g.triples) {
@@ -286,7 +286,7 @@ export interface ConfigureOptions {
  *
  * const t = configure(g);
  * console.log(t);
- * // Tree('b', [['/', 'bark-01'], [':ARG0', new Tree('d', [['/', 'dog']])]])
+ * // Tree('b', [['/', 'bark-01'], [':ARG0', ['d', [['/', 'dog']]]]])
  */
 export function configure(g: Graph, options: ConfigureOptions = {}): Tree {
   const { top = g.top, model = _default_model } = options;

--- a/src/lib/tree.spec.ts
+++ b/src/lib/tree.spec.ts
@@ -53,6 +53,46 @@ test('_init__', (t) => {
   t.deepEqual(t2.metadata, { snt: 'Alpha.' });
 });
 
+test('Tree.fromPenman', (t) => {
+  const tree = Tree.fromPenman('(b / bark-01 :ARG0 (d / dog))');
+  t.deepEqual(tree.node, [
+    'b',
+    [
+      ['/', 'bark-01'],
+      [':ARG0', ['d', [['/', 'dog']]]],
+    ],
+  ]);
+});
+
+test('toGraph', (t) => {
+  const tree = new Tree([
+    'b',
+    [
+      ['/', 'bark-01'],
+      ['ARG0', ['d', [['/', 'dog']]]],
+    ],
+  ]);
+
+  const g = tree.toGraph();
+  t.deepEqual(g.triples, [
+    ['b', ':instance', 'bark-01'],
+    ['b', ':ARG0', 'd'],
+    ['d', ':instance', 'dog'],
+  ]);
+});
+
+test('toPenman', (t) => {
+  const tree = new Tree([
+    'b',
+    [
+      ['/', 'bark-01'],
+      [':ARG0', ['d', [['/', 'dog']]]],
+    ],
+  ]);
+
+  t.deepEqual(tree.toPenman(), '(b / bark-01\n   :ARG0 (d / dog))');
+});
+
 //     def test_nodes(self, one_arg_node, reentrant):
 //         t = tree.Tree(one_arg_node)
 //         assert t.nodes() == [one_arg_node, ('b', [('/', 'beta')])]


### PR DESCRIPTION
The transformations between penman strings / graphs / trees have non-obvious names, so this PR adds aliases to the `Tree` and `Graph` classes to make these transformations more obvious. These include:

- `Graph.fromPenman()`: equivalent of `decode()`
- `graph.toPenman()`: equivalent of `encode()`
- `graph.toTree()`: equivalent of `configure()`
- `Tree.fromPenman()`: equivalent of `parse()`
- `tree.toPenman()`: equivalent of `format()`
- `tree.toGraph()`: equivalent of `interpret()`